### PR TITLE
Ignoring empty column names on importation process

### DIFF
--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -431,6 +431,9 @@ class Org(SmartModel):
             else:
                 spamreader = read_excel(tmp_file, index_col=False)
             headers = spamreader.columns.tolist()
+
+            # Removing empty columns name from CSV files imported
+            headers = [item for item in headers if "Unnamed" not in item]
         finally:
             os.remove(tmp_file)
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -2610,6 +2610,8 @@ class OrgCRUDL(SmartCRUDL):
                     spamreader = read_excel(import_file, index_col=False, dtype=str)
 
                 headers = spamreader.columns.tolist()
+                # Removing empty columns name from CSV files imported
+                headers = [item for item in headers if "Unnamed" not in item]
                 spamreader = spamreader.get_values().tolist()
                 spamreader.insert(0, headers)
 


### PR DESCRIPTION
Issue: CSV files with blank columns are unable to be imported https://app.asana.com/0/1152254835058569/1154018580653381/f