### PR TITLE
Bug fix: Prevent flow run deletion for editors

### DIFF
--- a/templates/flows/flow_run_table.haml
+++ b/templates/flows/flow_run_table.haml
@@ -11,7 +11,8 @@
   >
     %td
       .details.nobreak
-        .remove.icon-close{ onclick: 'deleteRun({{run.id}});' }
+        - if org_perms.flows.flowrun_delete
+          .remove.icon-close{ onclick: 'deleteRun({{run.id}});' }
         {{run.modified_on}}
 
     %td


### PR DESCRIPTION
Currently, an "editor" can see the "x" button beside the username when looking at the runs. However, when it clicks on it to remove the run and refresh the page, the run continue there. 

Action: Remove the "x" button to remove runs from editors.

Details:
https://app.asana.com/0/1159876841343577/1170302825643329/f