### PR TITLE
Django command: msg flow field backfill

### DIFF
--- a/docker/supervisor-celery.conf
+++ b/docker/supervisor-celery.conf
@@ -2,7 +2,7 @@
 
 [program:ccl-celery]
 environment = C_FORCE_ROOT="true"
-command = celery -A temba worker -B -Q celery --autoscale=%(ENV_CELERY_AUTOSCALE)s -O fair -n rapidpro.celery -l ERROR
+command = celery -A temba worker -B -Q celery --autoscale=%(ENV_CELERY_AUTOSCALE)s -O fair -n rapidpro.celery -l WARNING
 autostart = true
 autorestart = true
 stdout_logfile = /dev/stdout
@@ -13,7 +13,7 @@ stopwaitsecs = 120
 
 [program:ccl-celery-flows]
 environment = C_FORCE_ROOT="true"
-command = celery -A temba worker -Q msgs,flows,handler --autoscale=%(ENV_CELERY_FLOWS_AUTOSCALE)s -O fair -n rapidpro.celery_flows -l ERROR
+command = celery -A temba worker -Q msgs,flows,handler --autoscale=%(ENV_CELERY_FLOWS_AUTOSCALE)s -O fair -n rapidpro.celery_flows -l WARNING
 autostart = true
 autorestart = true
 stopwaitsecs = 120

--- a/temba/msgs/management/commands/backfill_msg_flow.py
+++ b/temba/msgs/management/commands/backfill_msg_flow.py
@@ -1,0 +1,25 @@
+from django.core.management import BaseCommand, CommandError
+
+from temba.msgs.tasks import backfill_msg_flow
+
+
+class Command(BaseCommand):  # pragma: no cover
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--orgs",
+            type=str,
+            action="store",
+            dest="orgs",
+            default=None,
+            help="comma separated list of IDs of orgs to populate the Msg flow field",
+        )
+
+    def handle(self, *args, **options):
+        org_list = options["orgs"]
+        if org_list is not None:
+            orgs = org_list.split(",")
+        else:
+            raise CommandError("Kindly provide at least one org ID")
+
+        for org_id in orgs:
+            backfill_msg_flow.delay(int(org_id))

--- a/temba/msgs/tasks.py
+++ b/temba/msgs/tasks.py
@@ -138,7 +138,11 @@ def backfill_msg_flow(org_id):
         flow_runs = FlowRun.objects.filter(id__in=run_ids).order_by("created_on")
 
         for run in flow_runs:
-            msgs_uuids = [item.get("msg", {}).get("uuid") for item in run.events if item.get("type") in ["msg_created", "msg_received"]]
+            msgs_uuids = [
+                item.get("msg", {}).get("uuid")
+                for item in run.events
+                if item.get("type") in ["msg_created", "msg_received"]
+            ]
             Msg.objects.filter(uuid__in=msgs_uuids).update(flow=run.flow)
 
         num_updated += len(run_ids)


### PR DESCRIPTION
For reference: the FlowRun events field is not used on this RapidPro version anymore, but we need to make sure that every message (for some organizations) has the new flow field (on the Msg model) fulfilled with its corresponding flow. So we are implementing this Django command so that we will be able to run it for some of our clients that need to have this field populated.

Note: from this update, we will follow some best practices and enable the celery log level to WARNING, that way we will be able to track some warning situations on our operation.